### PR TITLE
Fixed regex in show.html.erb that broke spotify

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,7 +14,7 @@
 			<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/<%=@trackid%>&amp;color=ff6600&amp;auto_play=false&amp;show_artwork=true"></iframe>
 		<% elsif track_url.include?('spotify.com')%>
 			<% @spotifyid = track_url %>
-				<iframe src="https://embed.spotify.com/?uri=spotify:track:<%=@spotifyid.sub(/^track/, '')%>" width="100%" height="80" frameborder="0" allowtransparency="true"></iframe>
+				<iframe src="https://embed.spotify.com/?uri=spotify:track:<%=@spotifyid.sub(/^(.*?)track\//, '')%>" width="100%" height="80" frameborder="0" allowtransparency="true"></iframe>
 		<% end %>
 
 		<h3>Comments:</h3>


### PR DESCRIPTION
Fixed regex for spotify links so embeds would work properly. The old regex didn't match anything.
